### PR TITLE
fixed dependency injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-
+        "php": "^7.1|^8.0",
         "sylius/sylius": "^1.1",
         "locastic/tcompayway": "^2.0"
     },

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -1,17 +1,20 @@
 services:
     locastic.sylius_ht_payway_plugin.validator.currency:
         class: Locastic\SyliusHTPayWayPlugin\Validator\Constraints\CurrencyValidator
+        public: true
         tags:
             - { name: validator.constraint_validator, alias: locastic_sylius_ht_payway_plugin_currency }
 
     locastic.sylius_ht_payway_plugin.form.type.ht_payway_gateway_configuration:
         class: Locastic\SyliusHTPayWayPlugin\Form\Type\HTPayWayOffsiteGatewayConfigurationType
+        public: true
         tags:
             - { name: sylius.gateway_configuration_type, type: ht_payway_offsite, label: locastic.sylius_ht_payway_plugin.ui.ht_payway_offsite }
             - { name: form.type }
 
     locastic.sylius_ht_payway_plugin.offsite_gateway_factory:
         class: Payum\Core\Bridge\Symfony\Builder\GatewayFactoryBuilder
+        public: true
         arguments:
             - Locastic\SyliusHTPayWayPlugin\HTPayWayOffsiteGatewayFactory
         tags:
@@ -19,20 +22,24 @@ services:
 
     locastic.sylius_ht_payway_plugin.action.convert_payment_to_htpayway:
         class: Locastic\SyliusHTPayWayPlugin\Bridge\ConvertPaymentToHTPayWayAction
+        public: true
         tags:
             - { name: payum.action, factory: ht_payway_offsite, prepend: true }
 
     locastic.sylius_ht_payway_plugin.action.capture_offsite:
         class: Locastic\SyliusHTPayWayPlugin\Action\CaptureOffsiteAction
+        public: true
         tags:
             - { name: payum.action, factory: ht_payway_offsite, alias: payum.action.capture }
 
     locastic.sylius_ht_payway_plugin.action.status:
         class: Locastic\SyliusHTPayWayPlugin\Action\StatusAction
+        public: true
         tags:
             - { name: payum.action, factory: ht_payway_offsite, alias: payum.action.status }
 
     locastic.sylius_ht_payway_plugin.action.convert_payment:
         class: Locastic\SyliusHTPayWayPlugin\Action\ConvertPaymentAction
+        public: true
         tags:
             - { name: payum.action, factory: ht_payway_offsite, alias: payum.action.convert_payment }


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | yes 
| Related tickets | #1 
| License         | MIT

This should fix error:
```
[2020-10-06 15:07:48] php.CRITICAL: Argument 1 passed to Payum\Core\Gateway::addAction() must implement interface Payum\Core\Action\ActionInterface, string given, called in /var/www/vendor/payum/payum/src/Payum/Core/CoreGatewayFactory.php on line 219 {"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Argument 1 passed to Payum\\Core\\Gateway::addAction() must implement interface Payum\\Core\\Action\\ActionInterface, string given, called in /var/www/vendor/payum/payum/src/Payum/Core/CoreGatewayFactory.php on line 219 at /var/www/vendor/payum/payum/src/Payum/Core/Gateway.php:66)"} []
```

Not sure if this is proper way to fix this issue. Please check.